### PR TITLE
Update stringtie.nf to handle larger RNAseq inputs by default

### DIFF
--- a/modules/stringtie.nf
+++ b/modules/stringtie.nf
@@ -2,9 +2,9 @@ process STRINGTIE {
     label 'stringtie'
     label 'campus'
 
-    time 2.h
+    time 24.h
     cpus 24
-    memory 80.GB
+    memory 150.GB
 
     input:
         path(bam)
@@ -25,9 +25,9 @@ process STRINGTIE_MIX {
     label 'stringtie'
     label 'campus'
 
-    time 2.h
+    time 24.h
     cpus 24
-    memory 80.GB
+    memory 150.GB
 
     input:
         path(bam_ill)


### PR DESCRIPTION
Time increased to 24h and memory increased to 150G by default to better handle large RNAseq datasets out-of-the-box.